### PR TITLE
Add 'auction' example

### DIFF
--- a/auction/README.md
+++ b/auction/README.md
@@ -1,0 +1,21 @@
+# Dutch Auction
+
+## Overview
+This project demonstrates how embedding DAML contracts can be used to prevent information leakage during multip-party transactions. The alternative is to use the [multi-party agreement protocol](https://docs.daml.com/daml/patterns/multiparty-agreement.html); however this reveals the identity of parties involved.
+This example is a simplified version of auctions [used for IPOs](https://en.wikipedia.org/wiki/Dutch_auction#Public_offerings). You can see a more elaborate example in [bond issuance](https://github.com/digital-asset/ex-bond-issuance).
+
+## Workflow
+There is a `seller` party, and two or more bidders. The `seller` generates an `Auction` contract, only vibile to her, and then embedds it into `AuctionInvitation`s for each individual participant. Each bidder responds to the invitaiton with a `Bid`, visible _only to him and the seller_. When the auction finishes at `Auction.end` time, an off-ledger process collects all the bids, caluclates the resulting allocations as an `AuctionResult`.
+
+## Building
+```
+daml build
+```
+
+## Testing
+```
+daml test
+```
+
+## Running
+todo - create an external process that monitors `Auctions` and triggers `CompleteAuction` at the appropriate time.

--- a/auction/daml.yaml
+++ b/auction/daml.yaml
@@ -1,0 +1,14 @@
+sdk-version: 0.13.18
+name: auction
+source: daml/Main.daml
+scenario: Main:setup
+parties:
+  - Seller
+  - Alice
+  - Bob
+version: 1.0.0
+exposed-modules:
+  - Main
+dependencies:
+  - daml-prim
+  - daml-stdlib

--- a/auction/daml/Auction.daml
+++ b/auction/daml/Auction.daml
@@ -1,0 +1,81 @@
+daml 1.2
+
+module Auction where
+
+import DA.List
+
+-- Used both to indicate a bid, and to show the final allocations.
+data Allocation = Allocation with 
+  party: Party
+  price: Decimal
+  quantity: Int
+    deriving (Show, Eq)
+
+-- Given the remaining quantity and requested allocation amount,
+-- calculate the resulting quantity and allocation.
+allocBids: Int -> Allocation -> (Int, Allocation)
+allocBids 0 a = (0, a with quantity = 0)
+allocBids remQty a = if remQty >= a.quantity then (remQty - a.quantity, a)
+                     else (0, a with quantity = remQty)
+
+-- Auction template visible only to the seller.
+template Auction
+  with
+    security: Text
+    quantity: Int
+    seller: Party
+    start: Time
+    end: Time
+  where
+    ensure quantity > 0 && start < end
+    signatory seller
+    -- Sent individually to each participant (bidder) at start of auction.
+    nonconsuming choice InviteBidder: ContractId AuctionInvitation 
+        with buyer: Party
+        controller seller
+          do create AuctionInvitation with buyer; auction = this
+    -- This should be triggered externally at the auction end time.
+    -- Collect the bids and publish allocations in `AuctionResult`.
+    choice CompleteAuction: ContractId AuctionResult
+        with bidIds: [ContractId Bid]
+        controller seller
+        do 
+          bids <- mapA (\id -> fetch id) bidIds
+          let requestedAllocs = map (\x -> x.allocation) bids
+              sortedAllocs = (sortOn (\x -> Down x.price) ) requestedAllocs
+              finalAllocs = mapAccumL allocBids this.quantity sortedAllocs -- TODO: filter qty = 0 allocs?
+          create AuctionResult with auction = this; allocations = finalAllocs._2
+
+-- Private to each buyer; contains a copy of the main Auction contract.
+template AuctionInvitation
+  with
+    auction: Auction
+    buyer: Party
+  where
+    signatory auction.seller
+    controller buyer can 
+      SubmitBid: ContractId Bid
+        with price: Decimal, quantity: Int
+        do
+          now <- getTime
+          assert(now <= auction.end &&
+                 now >= auction.start)
+          create Bid with auction; allocation = Allocation with party = buyer; price; quantity
+
+-- Used to place a bid on an active auction.
+template Bid
+  with
+    auction: Auction
+    allocation: Allocation
+  where
+    signatory allocation.party
+    observer auction.seller
+
+-- Created on successful completion of an auction, to display allocs.
+template AuctionResult
+  with
+    auction: Auction
+    allocations: [ Allocation ]
+  where
+    signatory auction.seller
+    observer map (\x -> x.party) allocations

--- a/auction/daml/Main.daml
+++ b/auction/daml/Main.daml
@@ -1,0 +1,36 @@
+daml 1.2
+
+module Main where
+
+import Auction
+import DA.Time
+
+-- Note that, in a real implementation, `CompleteAuction` would 
+-- be triggered externally by a process at `Auction.end` time.
+setup = scenario do
+  seller <- getParty "Seller"
+  alice <- getParty "Alice"
+  bob <- getParty "Bob"
+  now <- getTime
+  ipoId <- submit seller do
+    create Auction with 
+      security = "DA Ltd"
+      quantity = 1_000_000
+      seller = seller
+      start = now
+      end = addRelTime now (minutes 3)
+  aliceInviteId <- submit seller do
+    exercise ipoId InviteBidder with buyer = alice
+  bobInviteId <- submit seller do
+    exercise ipoId InviteBidder with buyer = bob
+  aliceBidId <- submit alice do
+    exercise aliceInviteId SubmitBid
+      with price = 99.0 ; quantity = 600_000
+  bobBidId <- submit bob do
+    exercise bobInviteId SubmitBid
+      with price = 97.0 ; quantity = 800_000
+  submit seller do
+    exercise ipoId CompleteAuction with bidIds = [aliceBidId, bobBidId]
+
+    
+    


### PR DESCRIPTION
@georg-da can you provide feedback? It's pretty bare-bones at the moment, without the client that would trigger the auction at the pre-determined `Auction.end` time. I'd like to add that separately later on, possibly with my experimental ledger API.