### PR TITLE
Sdk upgrade and minor cleanup

### DIFF
--- a/generic-auction-market/daml.yaml
+++ b/generic-auction-market/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.23
+sdk-version: 0.13.25
 name: generic-auction-market
 source: daml
 parties:

--- a/generic-auction-market/daml.yaml
+++ b/generic-auction-market/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.25
+sdk-version: 0.13.27
 name: generic-auction-market
 source: daml
 parties:

--- a/generic-auction-market/daml/Auction.daml
+++ b/generic-auction-market/daml/Auction.daml
@@ -20,10 +20,10 @@ allocBids _ remQty a = (remQty, a with quantity = 0.0)  -- reserve price not met
 
 
 disclosuresToParty : forall t.
-  (Asset t,
-  LockableInstance t,
-  FungibleInstance t,
-  TransferableInstance t) => t -> Text -> Party -> Update ()
+    (Asset t,
+    Template (Lockable t),
+    Template (Fungible t),
+    Template (Transferable t)) => t -> Text -> Party -> Update ()
 disclosuresToParty a l p = do
   (lockCid, _) <- fetchByKey @(Lockable t) (a.issuer, a.owner)
   lockCid <- exercise lockCid DiscloseLockable with party = p
@@ -49,9 +49,9 @@ data Allocation = Allocation
 
 
 template (Quantity t,
-          LockableInstance t,
-          FungibleInstance t,
-          TransferableInstance t,
+          Template (Lockable t),
+          Template (Fungible t),
+          Template (Transferable t),
           Template (Auction t)) => Auctioneer t
   with
     auctioneer : Party
@@ -80,7 +80,7 @@ template (Quantity t,
 
 template (Quantity t,
           Template (AuctionInvitation t),
-          BidInstance t,
+          Template (Bid t),
           Template (AuctionResult t)) => Auction t
   with
     asset            : t
@@ -170,10 +170,10 @@ template Asset t => Bid t
 
 
 template (Quantity t,
-          LockedInstance t,
-          FungibleInstance t,
-          TransferableInstance t,
-          LockableInstance t) => AuctionResult t
+          Template (Locked t),
+          Template (Fungible t),
+          Template (Transferable t),
+          Template (Lockable t)) => AuctionResult t
   with
     asset            : t
     auctioneer       : Party

--- a/generic-auction-market/daml/Auction.daml
+++ b/generic-auction-market/daml/Auction.daml
@@ -19,11 +19,13 @@ allocBids resPx remQty alloc | alloc.price >= resPx =
 allocBids _ remQty a = (remQty, a with quantity = 0.0)  -- reserve price not met
 
 
-disclosuresToParty : forall t.
+disclosuresToParty :
+  forall t.
     (Asset t,
-    Template (Lockable t),
-    Template (Fungible t),
-    Template (Transferable t)) => t -> Text -> Party -> Update ()
+     Template (Lockable t),
+     Template (Fungible t),
+     Template (Transferable t)) =>
+  t -> Text -> Party -> Update ()
 disclosuresToParty a l p = do
   (lockCid, _) <- fetchByKey @(Lockable t) (a.issuer, a.owner)
   lockCid <- exercise lockCid DiscloseLockable with party = p
@@ -48,11 +50,13 @@ data Allocation = Allocation
   deriving (Eq, Show)
 
 
-template (Quantity t,
-          Template (Lockable t),
-          Template (Fungible t),
-          Template (Transferable t),
-          Template (Auction t)) => Auctioneer t
+template
+    (Quantity t,
+     Template (Lockable t),
+     Template (Fungible t),
+     Template (Transferable t),
+     Template (Auction t)) =>
+    Auctioneer t
   with
     auctioneer : Party
     observers  : [Party]
@@ -78,10 +82,12 @@ template (Quantity t,
           create $ Auction with asset, auctioneer, reservePrice, auctionId, participants = [], oversightParties
 
 
-template (Quantity t,
-          Template (AuctionInvitation t),
-          Template (Bid t),
-          Template (AuctionResult t)) => Auction t
+template
+    (Quantity t,
+     Template (AuctionInvitation t),
+     Template (Bid t),
+     Template (AuctionResult t)) =>
+    Auction t
   with
     asset            : t
     auctioneer       : Party
@@ -120,8 +126,10 @@ template (Quantity t,
             unfilledQty [] oversightParties
 
 
-template (Quantity t,
-          Template (Bid t)) => AuctionInvitation t
+template
+    (Quantity t,
+     Template (Bid t)) =>
+    AuctionInvitation t
   with
     asset            : t
     auctioneer       : Party
@@ -169,11 +177,13 @@ template Asset t => Bid t
     maintainer key._1
 
 
-template (Quantity t,
-          Template (Locked t),
-          Template (Fungible t),
-          Template (Transferable t),
-          Template (Lockable t)) => AuctionResult t
+template
+    (Quantity t,
+     Template (Locked t),
+     Template (Fungible t),
+     Template (Transferable t),
+     Template (Lockable t)) =>
+    AuctionResult t
   with
     asset            : t
     auctioneer       : Party

--- a/generic-auction-market/daml/Fungible.daml
+++ b/generic-auction-market/daml/Fungible.daml
@@ -30,8 +30,8 @@ template Quantity t => Fungible t
           assert (asset.issuer == issuer)
           assert (asset.amount > splitAmount)
           archive assetCid
-          splitCid <- create $ asset with amount = splitAmount
-          restCid <- create $ asset with amount = asset.amount - splitAmount
+          splitCid <- create asset with amount = splitAmount
+          restCid <- create asset with amount = asset.amount - splitAmount
           return (splitCid, restCid)
 
       nonconsuming MergeAssets : (ContractId t)
@@ -46,7 +46,7 @@ template Quantity t => Fungible t
           assert (first == second with amount = first.amount)
           archive firstAssetCid
           archive secondAssetCid
-          create $ first with amount = first.amount + second.amount
+          create first with amount = first.amount + second.amount
 
       DiscloseFungible : ContractId (Fungible t)
         with

--- a/generic-auction-market/daml/Issuer.daml
+++ b/generic-auction-market/daml/Issuer.daml
@@ -6,9 +6,11 @@ import Transferable
 import Locked
 
 
-template (Template (Fungible t),
-          Template (Lockable t),
-          Template (Transferable t)) => Issuer t
+template
+    (Template (Fungible t),
+     Template (Lockable t),
+     Template (Transferable t)) =>
+    Issuer t
   with
     issuer    : Party
     observers : [Party]

--- a/generic-auction-market/daml/Locked.daml
+++ b/generic-auction-market/daml/Locked.daml
@@ -38,7 +38,7 @@ template (Asset t, Template (Locked t)) => Lockable t
                   then observers else party :: observers
 
 
-template (Asset t) => Locked t
+template Asset t => Locked t
   with
     asset     : t
     escrow    : Party

--- a/generic-auction-market/daml/Locked.daml
+++ b/generic-auction-market/daml/Locked.daml
@@ -61,7 +61,7 @@ template Asset t => Locked t
         with
           newOwner : Party
         do
-          create $ asset with owner = newOwner
+          create asset with owner = newOwner
 
       DiscloseLocked : ContractId (Locked t)
         with

--- a/generic-auction-market/daml/SecondaryMarket.daml
+++ b/generic-auction-market/daml/SecondaryMarket.daml
@@ -15,12 +15,13 @@ verifyPrice Market _ _ = True
 verifyPrice (Limit l) Buy p = p <= l
 verifyPrice (Limit l) Sell p = p >= l
 
-disclosuresToParty : forall t.
-  (Asset t,
-  LockableInstance t,
-  LockedInstance t,
-  FungibleInstance t,
-  TransferableInstance t) => t -> Text -> Party -> Update ()
+disclosuresToParty :
+  forall t.
+    (Asset t,
+    Template (Lockable t),
+    Template (Locked t),
+    Template (Fungible t),
+    Template (Transferable t)) => t -> Text -> Party -> Update ()
 disclosuresToParty a l p = do
   (lockCid, _) <- fetchByKey @(Lockable t) (a.issuer, a.owner)
   lockCid <- exercise lockCid DiscloseLockable with party = p
@@ -36,10 +37,10 @@ disclosuresToParty a l p = do
       return ()
 
 
-template (LockableInstance t,
-          LockedInstance t,
-          FungibleInstance t,
-          TransferableInstance t,
+template (Template (Lockable t),
+          Template (Locked t),
+          Template (Fungible t),
+          Template (Transferable t),
           Template (BrokerSellInstruction t),
           Template (BrokerBuyInstruction t)) => BrokerDealer t
   with
@@ -81,9 +82,9 @@ template (LockableInstance t,
 
 
 template (Quantity t,
-          LockedInstance t,
-          FungibleInstance t,
-          TransferableInstance t,
+          Template (Locked t),
+          Template (Fungible t),
+          Template (Transferable t),
           Template (Trade t),
           Template (MarketBid t)) => BrokerBuyInstruction t
   with
@@ -158,13 +159,13 @@ template (Quantity t,
 
 
 template (Asset t,
-          LockableInstance t,
-          FungibleInstance t,
-          TransferableInstance t,
-          LockedInstance t,
+          Template (Lockable t),
+          Template (Fungible t),
+          Template (Transferable t),
+          Template (Locked t),
           Template (Trade t),
           Template (MarketOffer t),
-          MarketBidInstance t) => BrokerSellInstruction t
+          Template (MarketBid t)) => BrokerSellInstruction t
   with
     asset         : t
     brokerDealer  : Party
@@ -239,9 +240,9 @@ template Trade t
 
 
 template (Quantity t,
-          LockedInstance t,
+          Template (Locked t),
           Template (Trade t),
-          BrokerBuyInstructionInstance t) => MarketOffer t
+          Template (BrokerBuyInstruction t)) => MarketOffer t
   with
     brokerDealer  : Party
     brokerDealers : [Party]

--- a/generic-auction-market/daml/SecondaryMarket.daml
+++ b/generic-auction-market/daml/SecondaryMarket.daml
@@ -18,10 +18,11 @@ verifyPrice (Limit l) Sell p = p >= l
 disclosuresToParty :
   forall t.
     (Asset t,
-    Template (Lockable t),
-    Template (Locked t),
-    Template (Fungible t),
-    Template (Transferable t)) => t -> Text -> Party -> Update ()
+     Template (Lockable t),
+     Template (Locked t),
+     Template (Fungible t),
+     Template (Transferable t)) =>
+  t -> Text -> Party -> Update ()
 disclosuresToParty a l p = do
   (lockCid, _) <- fetchByKey @(Lockable t) (a.issuer, a.owner)
   lockCid <- exercise lockCid DiscloseLockable with party = p
@@ -37,12 +38,14 @@ disclosuresToParty a l p = do
       return ()
 
 
-template (Template (Lockable t),
-          Template (Locked t),
-          Template (Fungible t),
-          Template (Transferable t),
-          Template (BrokerSellInstruction t),
-          Template (BrokerBuyInstruction t)) => BrokerDealer t
+template
+    (Template (Lockable t),
+     Template (Locked t),
+     Template (Fungible t),
+     Template (Transferable t),
+     Template (BrokerSellInstruction t),
+     Template (BrokerBuyInstruction t)) =>
+    BrokerDealer t
   with
     brokerDealer : Party
     observers    : [Party]
@@ -81,12 +84,14 @@ template (Template (Lockable t),
             buyer brokerDealer orderType quantity instructionId
 
 
-template (Quantity t,
-          Template (Locked t),
-          Template (Fungible t),
-          Template (Transferable t),
-          Template (Trade t),
-          Template (MarketBid t)) => BrokerBuyInstruction t
+template
+    (Quantity t,
+     Template (Locked t),
+     Template (Fungible t),
+     Template (Transferable t),
+     Template (Trade t),
+     Template (MarketBid t)) =>
+    BrokerBuyInstruction t
   with
     buyer         : Party
     brokerDealer  : Party
@@ -134,8 +139,10 @@ template (Quantity t,
           create $ MarketBid @t buyer brokerDealer price quantity brokerDealers
 
 
-template (Quantity t,
-          Template (Trade t)) => MarketBid t
+template
+    (Quantity t,
+     Template (Trade t)) =>
+    MarketBid t
   with
     buyer         : Party
     brokerDealer  : Party
@@ -158,14 +165,16 @@ template (Quantity t,
           create $ Trade with asset, price = price, buyer, seller = brokerDealer
 
 
-template (Asset t,
-          Template (Lockable t),
-          Template (Fungible t),
-          Template (Transferable t),
-          Template (Locked t),
-          Template (Trade t),
-          Template (MarketOffer t),
-          Template (MarketBid t)) => BrokerSellInstruction t
+template
+    (Asset t,
+     Template (Lockable t),
+     Template (Fungible t),
+     Template (Transferable t),
+     Template (Locked t),
+     Template (Trade t),
+     Template (MarketOffer t),
+     Template (MarketBid t)) =>
+    BrokerSellInstruction t
   with
     asset         : t
     brokerDealer  : Party
@@ -239,10 +248,12 @@ template Trade t
     signatory buyer, seller
 
 
-template (Quantity t,
-          Template (Locked t),
-          Template (Trade t),
-          Template (BrokerBuyInstruction t)) => MarketOffer t
+template
+    (Quantity t,
+     Template (Locked t),
+     Template (Trade t),
+     Template (BrokerBuyInstruction t)) =>
+    MarketOffer t
   with
     brokerDealer  : Party
     brokerDealers : [Party]

--- a/generic-auction-market/daml/Transferable.daml
+++ b/generic-auction-market/daml/Transferable.daml
@@ -29,7 +29,7 @@ template Asset t => Transferable t
           assert (asset.owner == owner)
           assert (asset.issuer == issuer)
           archive assetCid
-          create $ asset with owner = newOwner
+          create asset with owner = newOwner
 
       DiscloseTransferable : ContractId (Transferable t)
         with


### PR DESCRIPTION
The main purpose of this is to exercise @hurryabit's fix to remove `XInstance` references in favour of `Template (X t)` constraints. It's also nice to be up to date with the latest SDK.

@dimitri-da We may want to check that this still runs as expected on DABL.

There are a couple of commits with formatting changes, feel free to drop those if not to your taste.