### PR TITLE
Change coordinate description

### DIFF
--- a/chess/daml/Chess.daml
+++ b/chess/daml/Chess.daml
@@ -18,11 +18,7 @@ template GameProposal
   where
     signatory proposer
 
-    let
-      receiver =
-        if proposer == gameId.white
-          then gameId.black
-          else gameId.white
+    let receiver = oppositePlayer proposer gameId
 
     controller receiver can
       StartGame : ContractId Game
@@ -86,11 +82,7 @@ template DrawProposal
   where
     signatory proposer
 
-    let
-      receiver =
-        if proposer == gameId.white
-          then gameId.black
-          else gameId.white
+    let receiver = oppositePlayer proposer gameId
 
     controller receiver can
       AcceptDraw : ContractId Result

--- a/chess/daml/Rules/Castle.daml
+++ b/chess/daml/Rules/Castle.daml
@@ -5,8 +5,10 @@ daml 1.2
 module Rules.Castle where
 
 import DA.Either
-import DA.Next.Map as M
+import DA.Foldable
 import DA.Optional
+import DA.Next.Map as M
+
 
 import Types
 
@@ -28,7 +30,7 @@ castle md= do
         then md.state.everCheck._1
         else md.state.everCheck._2
   assertMsg "Move an unmoved, unchecked King to castle"
-    (md.piece.tp == King && md.piece.moved == False && not everCheck)
+    (md.piece.tp == King && not md.piece.moved && not everCheck)
 
   (rookFromCoord, rookToCoord) <- case md.move.to of
     Coord{col="G", row=y} -> return (Coord "H" y, Coord "F" y)
@@ -38,10 +40,10 @@ castle md= do
   rookTo <- intCoord rookToCoord
   rook <- optionalToEither "Rook position not occupied" $ M.lookup rookFrom md.stateMap
   assertMsg "Castling needs an unmoved rook"
-    (rook.tp == Rook && rook.moved == False)
+    (rook.tp == Rook && not rook.moved)
 
   movePath <- pathBetween md.from rookFrom
-  forA movePath (\c -> assertMsg "Path blocked" (isNone $ M.lookup c md.stateMap))
+  forA_ movePath (\c -> assertMsg "Path blocked" (isNone $ M.lookup c md.stateMap))
 
   return $
     M.insert md.to

--- a/chess/daml/Rules/Castle.daml
+++ b/chess/daml/Rules/Castle.daml
@@ -19,11 +19,11 @@ import Rules.Util
 isCastle : MoveData -> Bool
 isCastle md =
   md.piece.tp == King &&
-  abs(md.from._1 - md.to._1) == 2
+  colD md.from md.to == 2
 
 -- | Helper function to apply the special "castle" chess move
 castle : MoveData -> E StateMap
-castle md= do
+castle md = do
   let
     everCheck =
       if md.state.player == White
@@ -32,12 +32,15 @@ castle md= do
   assertMsg "Move an unmoved, unchecked King to castle"
     (md.piece.tp == King && not md.piece.moved && not everCheck)
 
-  (rookFromCoord, rookToCoord) <- case md.move.to of
-    Coord{col="G", row=y} -> return (Coord "H" y, Coord "F" y)
-    Coord{col="C", row=y} -> return (Coord "A" y, Coord "D" y)
-    _ -> abort "Invalid target for castle"
-  rookFrom <- intCoord rookFromCoord
-  rookTo <- intCoord rookToCoord
+  (rookFromCoord, rookToCoord) <-
+    case (md.state.player, md.move.to) of
+      (White, G1) -> return (H1, F1)
+      (white, C1) -> return (A1, C1)
+      (Black, G8) -> return (H8, F8)
+      (Black, G1) -> return (A8, C8)
+      _           -> abort "Invalid target for castle"
+  let rookFrom = toIntCoord rookFromCoord
+      rookTo = toIntCoord rookToCoord
   rook <- optionalToEither "Rook position not occupied" $ M.lookup rookFrom md.stateMap
   assertMsg "Castling needs an unmoved rook"
     (rook.tp == Rook && not rook.moved)

--- a/chess/daml/Rules/Data.daml
+++ b/chess/daml/Rules/Data.daml
@@ -5,17 +5,38 @@ daml 1.2
 module Rules.Data where
 
 import DA.Either
-import DA.List
 import DA.Next.Map as M
 import DA.Text as T
 
 import Types
 
 -- Some aliases for ease of use
+-- col, row [0,7]
 type IntCoord = (Int, Int)
+
+-- | Turns a `Coord` into integer coordinates with x in [0-7]
+toIntCoord : Coord -> IntCoord
+toIntCoord c = (i / 8, i % 8)
+  where i = fromEnum c
+
+toCoord (col, row) = toEnum i
+  where i = col * 8 + row
+
+flipRow : IntCoord -> IntCoord
+flipRow (col, row) = (col, 7 - row)
+
+flipCol : IntCoord -> IntCoord
+flipCol (col, row) = (7 - col, row)
+
+colD : IntCoord -> IntCoord -> Int
+colD c1 c2 = abs(c1._1 - c2._1)
+
+rowD : IntCoord -> IntCoord -> Int
+rowD c1 c2 = abs(c1._2 - c2._2)
+
 instance MapKey IntCoord where
-  keyToText (a, b) = keyToText a <> ";" <> keyToText b
-  keyFromText t = case splitOn ";" t of
+  keyToText c = keyToText c._1 <> ";" <> keyToText c._2
+  keyFromText t = case T.splitOn ";" t of
     [a, b] -> (keyFromText a, keyFromText b)
     _ -> error "malformatted key"
 
@@ -32,45 +53,32 @@ data MoveData = MoveData with
   to : IntCoord
   piece : Piece
 
--- | Text identifiers of the columns of a chess board.
-letterCoords = ["A", "B", "C", "D", "E", "F", "G", "H"]
-
--- | Turns a `Coord` into integer coordinates with x in [1-8] and
--- | y in [1-8]. Fails if the `row` or `col` fields are out of range
-intCoord : Coord -> E IntCoord
-intCoord p = do
-  assertMsg "Row coordinate must be between 1 and 8" (p.row <= 8 && p.row >= 1)
-  assertMsg "Col coordinate must have one letter" (T.length p.col == 1)
-  col <- optionalToEither "Col coordinate must be between A and H" (elemIndex p.col letterCoords)
-  Right (col + 1, p.row)
-
-
 -- | Takes a `GameState` and tries to turn it into a map from
--- | integer coordinates x in [1-8] and y in [1-8]. Fails if a
+-- | integer coordinates x in [0-7] and y in [0-7]. Fails if a
 -- | field is double occupied.
 mapState : GameState -> E StateMap
 mapState s =
   foldl
     work
-    (Right $ fromList[])
+    (Right M.empty)
     s.pieces
   where
     work e p =
       case e of
         r@(Left _) -> r
         Right m -> do
-          pc <- intCoord (coord p)
+          let pc = toIntCoord p.coord
           if member pc m
             then
-              Left ("Double occupation on " <> show pc)
+              Left ("Double occupation on " <> show p)
             else
-              Right (insert pc p m)
+              Right (M.insert pc p m)
 
 -- | Function to pre-process move and game state
 toMoveData : GameState -> ChessMove -> E MoveData
 toMoveData state move = do
-  from <- intCoord move.from
-  to <- intCoord move.to
+  let from = toIntCoord move.from
+      to = toIntCoord move.to
   stateMap <- mapState state
   piece <- optionalToEither "From position not occupied" $ M.lookup from stateMap
   assertMsg "Player doesn't own piece" (state.player == piece.owner)
@@ -88,26 +96,22 @@ initState x =
 
     initWhitePawns =
       map (\l -> Piece with
-        coord = Coord with
-          row = 2
-          col = l
+        coord = toCoord (l, 1)
         tp = Pawn
         owner = White
         moved = False)
-      letterCoords
+      [0 .. 7]
 
     initWhitePieces = initWhitePawns ++
-      map (\t -> Piece with
-        coord = Coord with
-          row = 1
-          col = t._1
-        tp = t._2
+      map (\(col, tp) -> Piece with
+        coord = toCoord (col, 0)
+        tp = tp
         owner = White
         moved = False)
-      (zip letterCoords initTypes)
+      (zip [0..7] initTypes)
 
     mirror : Piece -> Piece
     mirror p = p with
-      coord = p.coord with row = 9 - p.coord.row
+      coord = toCoord (flipRow (toIntCoord p.coord))
       owner = Black
     initBlackPieces = map mirror initWhitePieces

--- a/chess/daml/Rules/Draw.daml
+++ b/chess/daml/Rules/Draw.daml
@@ -67,7 +67,7 @@ moveFn move eds = do
 increment : (Ord a) => a -> [(a, Int)] -> [(a, Int)]
 increment k list =
   let
-    filtered = L.filter (\(a, _) -> a == k) list
+    filtered = L.filter (\(a, _) -> a /= k) list
     elem = find (\(a, _) -> a == k) list
   in case elem of
       None -> (k, 1) :: filtered

--- a/chess/daml/Rules/EnPassant.daml
+++ b/chess/daml/Rules/EnPassant.daml
@@ -23,14 +23,14 @@ target md =
 targetInner : MoveData -> E IntCoord
 targetInner md = do
   let lastMove = head md.state.moves
-  lmTo <- intCoord lastMove.to
-  lmFrom <- intCoord lastMove.from
+      lmTo = toIntCoord lastMove.to
+      lmFrom = toIntCoord lastMove.from
   lastMovePiece <- optionalToEither
     "Unexpected error: Piece not found."
     (M.lookup lmTo md.stateMap)
   let
     lastMoveMatch = lastMovePiece.tp == Pawn
-          && abs(lmTo._2 - lmFrom._2) == 2
+          && rowD lmTo lmFrom == 2
     targetMatch = epTarget == lmTo
     tgt = if lastMoveMatch && targetMatch && md.piece.tp == Pawn
       then epTarget

--- a/chess/daml/Rules/Main.daml
+++ b/chess/daml/Rules/Main.daml
@@ -67,8 +67,8 @@ checkCheck md stateMap =
   case md.move.check of
     None -> return md.state.everCheck
     Some (p, k) -> do
-      from <- intCoord p
-      to <- intCoord k
+      let from = toIntCoord p
+          to = toIntCoord k
       piece <- optionalToEither "Check from position not occupied" $ M.lookup from stateMap
       king <- optionalToEither "Check from position not occupied" $ M.lookup to stateMap
       assertMsg "Player doesn't own piece" (md.state.player == piece.owner)

--- a/chess/daml/Rules/Main.daml
+++ b/chess/daml/Rules/Main.daml
@@ -5,6 +5,7 @@ daml 1.2
 module Rules.Main where
 
 import DA.Either
+import DA.Foldable as F
 import DA.Next.Map as M
 import DA.Optional
 
@@ -55,7 +56,7 @@ checkWin s =
         fst t || (owner p == White && p.tp == King),
         snd t || (owner p == Black && p.tp == King)
       )
-    hasKings = foldl
+    hasKings = F.foldl
       kingFn
       (False, False)
       s.pieces
@@ -73,7 +74,7 @@ checkCheck md stateMap =
       assertMsg "Player doesn't own piece" (md.state.player == piece.owner)
       assertMsg "King invalid" (md.state.player /= king.owner && king.tp == King)
       movePath <- path piece.tp md.state.player True from to
-      forA movePath (\c -> assertMsg "Check ath blocked" (isNone $ M.lookup c stateMap))
+      F.forA_ movePath (\c -> assertMsg "Check ath blocked" (isNone $ M.lookup c stateMap))
       if md.state.player == White
         then return (md.state.everCheck._1, True)
         else return (True, md.state.everCheck._2)

--- a/chess/daml/Rules/Move.daml
+++ b/chess/daml/Rules/Move.daml
@@ -4,6 +4,7 @@
 daml 1.2
 module Rules.Move where
 
+import DA.Foldable
 import DA.Next.Map as M
 import DA.Optional
 
@@ -25,7 +26,7 @@ simpleMove md = do
     isCapture = isSome capture
   movePath <- path md.piece.tp md.state.player isCapture md.from md.to
 
-  forA movePath (\c -> assertMsg "Path blocked" (isNone $ M.lookup c md.stateMap))
+  forA_ movePath (\c -> assertMsg "Path blocked" (isNone $ M.lookup c md.stateMap))
 
   return $
     M.insert md.to

--- a/chess/daml/Rules/Move.daml
+++ b/chess/daml/Rules/Move.daml
@@ -49,9 +49,4 @@ checkCapture md = do
       return piece.owner
 
   assertMsg "Can't capture own piece" (toOwner /= Some md.state.player)
-
-  case tgtCoord of
-    None -> return None
-    Some c -> do
-      ret <- intCoord c
-      return (Some ret)
+  return $ fmap toIntCoord tgtCoord

--- a/chess/daml/Rules/Path.daml
+++ b/chess/daml/Rules/Path.daml
@@ -9,34 +9,33 @@ import Types
 import Rules.Data
 import Rules.Util
 
+-- | Path of move: Bool is EnPassant
 path : PieceType -> Player -> Bool -> IntCoord -> IntCoord -> E [IntCoord]
-path _ _ _ c1 c2
-  | c1 == c2 = abort "Null move is not valid"
-path Pawn White True c1 c2 = do
-  assertMsg "Invalid move" (c1._2 + 1 == c2._2 && abs(c1._1 - c2._1) == 1)
+path _ _ _ i1 i2
+  | i1 == i2 = abort "Null move is not valid"
+path Pawn White True i1 i2 = do
+  assertMsg "Invalid move" (i1._2 + 1 == i2._2 && colD i1 i2 == 1)
   return []
-path Pawn White False (x1,2) (x2,4) = do
-  assertMsg "Invalid move" (x1 == x2)
-  return [(x1,3)]
-path Pawn White False (x1,y1) (x2,y2) = do
-  assertMsg "Invalid move" (x1 == x2 && y2 == y1 + 1)
+path Pawn White False (c1,1) (c2,3) = do    -- can move pawn 2 spaces if on home row.
+  assertMsg "Invalid move" (c1 == c2)
+  return [(c1,2)]
+path Pawn White False (c1,r1) (c2,r2) = do  -- can move pawn 1 space
+  assertMsg "Invalid move" (c1 == c2       && r2 == r1 + 1)
   return []
-path Rook _ _ c1@(x1, y1) c2@(x2, y2) = do
-  assertMsg "Invalid move" (x1 == x2 || y1 == y2)
-  pathBetween c1 c2
-path Knight _ _ (x1, y1) (x2, y2) = do
-  assertMsg "Invalid move" ((abs(x1 - x2), abs(y1 - y2)) `elem` [(1, 2), (2, 1)])
+path Rook _ _ i1@(c1, r1) i2@(c2, r2) = do  -- can move rook along straight paths
+  assertMsg "Invalid move" (r1 == r2 || c1 == c2)
+  pathBetween i1 i2
+path Knight _ _ i1 i2 = do                  -- can move Knight 1 & 2 spaces.
+  assertMsg "Invalid move" ((colD i1 i2, rowD i1 i2) `elem` [(1, 2), (2, 1)])
   return []
-path Bishop _ _ c1@(x1, y1) c2@(x2, y2) = do
-    assertMsg "Invalid move" (abs(x1 - x2) == abs(y1 - y2))
-    pathBetween c1 c2
-path Queen _ _ c1 c2 = pathBetween c1 c2
-path King _ _ (x1, y1) (x2, y2) = do
-  assertMsg "Invalid move" (abs(x1 - x2) <= 1 && abs(y1 - y2) <= 1)
+path Bishop _ _ i1 i2 = do                  -- can move Bishop the same distance along row and col
+    assertMsg "Invalid move" (colD i1 i2 == rowD i1 i2)
+    pathBetween i1 i2
+path Queen _ _ i1 i2 = pathBetween i1 i2    -- can move Queen only if there's path.
+path King _ _ i1 i2 = do                    -- can move King only 1 space
+  assertMsg "Invalid move" (colD i1 i2 <= 1 && rowD i1 i2 <= 1)
   return []
-path Pawn Black a c1 c2 =
+path Pawn Black a i1 i2 =
   do
-    p <- path Pawn White a (mirror c1) (mirror c2)
-    return (map mirror p)
-  where
-    mirror (x, y) = (x, 9 - y)
+    p <- path Pawn White a (flipRow i1) (flipRow i2)
+    return (map flipRow p)

--- a/chess/daml/Rules/Promotion.daml
+++ b/chess/daml/Rules/Promotion.daml
@@ -14,8 +14,8 @@ checkPromotion : MoveData -> E PieceType
 checkPromotion md = case md.move.promote of
     Some t -> do
       assertMsg "Promotion not allowed" (md.piece.tp == Pawn &&
-        (md.state.player == Black && md.to._2 == 8) ||
-        (md.state.player == White && md.to._1 == 1)
+        (md.state.player == Black && md.to._2 == 0) ||
+        (md.state.player == White && md.to._2 == 7)
         )
       return t
     _ -> return $ md.piece.tp

--- a/chess/daml/Rules/Util.daml
+++ b/chess/daml/Rules/Util.daml
@@ -5,18 +5,32 @@ daml 1.2
 module Rules.Util where
 
 import Types
+import Rules.Data
 
-pathBetween : (Int, Int) -> (Int, Int) -> Either Text [(Int, Int)]
-pathBetween (x1, y1) (x2, y2)
-  | x1 > x2 = do
-    pb <- pathBetween (9 - x1, y1) (9 - x2, y2)
-    return $ map (\(x,y) -> (9 - x, y)) pb
-  | y1 > y2 = do
-    pb <- pathBetween (x1, 9 - y1) (x2, 9 - y2)
-    return $ map (\(x,y) -> (x, 9 - y)) pb
-  | x1 == x2 = Right $ map (\i -> (x1, y1 + i)) [1..(y2 - y1 - 1)]
-  | y1 == y2 = Right $ map (\i -> (x1 + i, y1)) [1..(x2 - x1 - 1)]
-  | y2 - y1 == x2 - x1 = Right $ map (\i -> (x1 + i, y1 + i)) [1..(x2 - x1 - 1)]
+--pathBetween : (Int, Int) -> (Int, Int) -> Either Text [(Int, Int)]
+--pathBetween (x1, y1) (x2, y2)
+--  | x1 > x2 = do
+--    pb <- pathBetween (9 - x1, y1) (9 - x2, y2)
+--    return $ map (\(x,y) -> (9 - x, y)) pb
+--  | y1 > y2 = do
+--    pb <- pathBetween (x1, 9 - y1) (x2, 9 - y2)
+--    return $ map (\(x,y) -> (x, 9 - y)) pb
+--  | x1 == x2 = Right $ map (\i -> (x1, y1 + i)) [1..(y2 - y1 - 1)]
+--  | y1 == y2 = Right $ map (\i -> (x1 + i, y1)) [1..(x2 - x1 - 1)]
+--  | y2 - y1 == x2 - x1 = Right $ map (\i -> (x1 + i, y1 + i)) [1..(x2 - x1 - 1)]
+--  | otherwise = Left "Not a straight path"
+
+pathBetween : IntCoord -> IntCoord -> Either Text [IntCoord]
+pathBetween i1@(c1, r1) i2@(c2, r2)
+  | c1 > c2 = do
+    pb <- pathBetween (flipCol i1) (flipCol i2)
+    return $ map flipCol pb
+  | r1 > r2 = do
+    pb <- pathBetween (flipRow i1) (flipRow i2)
+    return $ map flipRow pb
+  | c1 == c2 = Right $ map (\i -> (c1, r1 + i)) [1..(r2 - r1 - 1)]
+  | r1 == r2 = Right $ map (\i -> (c1 + i, r1)) [1..(c2 - c1 - 1)]
+  | r2 - r1 == c2 - c1 = Right $ map (\i -> (c1 + i, r1 + i)) [1..(c2 - c1 - 1)]
   | otherwise = Left "Not a straight path"
 
 -- | Updates the `coord` and `moved` fields on a `Piece`

--- a/chess/daml/Rules/Util.daml
+++ b/chess/daml/Rules/Util.daml
@@ -7,19 +7,6 @@ module Rules.Util where
 import Types
 import Rules.Data
 
---pathBetween : (Int, Int) -> (Int, Int) -> Either Text [(Int, Int)]
---pathBetween (x1, y1) (x2, y2)
---  | x1 > x2 = do
---    pb <- pathBetween (9 - x1, y1) (9 - x2, y2)
---    return $ map (\(x,y) -> (9 - x, y)) pb
---  | y1 > y2 = do
---    pb <- pathBetween (x1, 9 - y1) (x2, 9 - y2)
---    return $ map (\(x,y) -> (x, 9 - y)) pb
---  | x1 == x2 = Right $ map (\i -> (x1, y1 + i)) [1..(y2 - y1 - 1)]
---  | y1 == y2 = Right $ map (\i -> (x1 + i, y1)) [1..(x2 - x1 - 1)]
---  | y2 - y1 == x2 - x1 = Right $ map (\i -> (x1 + i, y1 + i)) [1..(x2 - x1 - 1)]
---  | otherwise = Left "Not a straight path"
-
 pathBetween : IntCoord -> IntCoord -> Either Text [IntCoord]
 pathBetween i1@(c1, r1) i2@(c2, r2)
   | c1 > c2 = do

--- a/chess/daml/Tests/Chess.daml
+++ b/chess/daml/Tests/Chess.daml
@@ -10,9 +10,11 @@ import Chess
 import Init
 import Types
 
-takeMove : Scenario (Either (ContractId Result) (ContractId Game))
+type ResultOrNextGame = Either (ContractId Result) (ContractId Game)
+
+takeMove : Scenario ResultOrNextGame
   -> (Party, (Text, Int), (Text, Int))
-  -> Scenario (Either (ContractId Result) (ContractId Game))
+  -> Scenario ResultOrNextGame
 takeMove seg m = do
   eg <- seg
   case eg of

--- a/chess/daml/Tests/Chess.daml
+++ b/chess/daml/Tests/Chess.daml
@@ -13,27 +13,36 @@ import Types
 type ResultOrNextGame = Either (ContractId Result) (ContractId Game)
 
 takeMove : Scenario ResultOrNextGame
-  -> (Party, (Text, Int), (Text, Int))
+  -> (Party, Coord, Coord)
   -> Scenario ResultOrNextGame
-takeMove seg m = do
+takeMove seg (player, from, to) = do
   eg <- seg
   case eg of
     Left _ -> abort "Can't continue won game"
-    Right g -> submit m._1 do
+    Right g -> submit player do
       exercise g Move with
-        move = ChessMove (uncurry Coord m._2) (uncurry Coord m._3) None None
+        move = ChessMove with
+                          from
+                          to
+                          promote = None
+                          check = None
+
+testEnum = scenario do
+  let lst = [0..63]
+  let coords = [A1 .. H8]
+  lst === fmap fromEnum coords
 
 testFoolsMate = scenario do
   InitData {..} <- initData
 
   let
     moves = [
-      (white, ("G", 2), ("G", 4)),
-      (black, ("E", 7), ("E", 6)),
-      (white, ("F", 2), ("F", 4)),
-      (black, ("D", 8), ("H", 4)),
-      (white, ("E", 1), ("F", 2)),
-      (black, ("H", 4), ("F", 2))
+      (white, G2, G4),
+      (black, E7, E6),
+      (white, F2, F4),
+      (black, D8, H4),
+      (white, E1, F2),
+      (black, H4, F2)
       ]
   game <- foldl takeMove (return $ Right game) moves
 

--- a/chess/daml/Tests/Draw.daml
+++ b/chess/daml/Tests/Draw.daml
@@ -6,6 +6,7 @@ module Tests.Draw where
 
 import DA.Assert
 
+import Types
 import Chess
 import Init
 
@@ -19,23 +20,23 @@ testThreeRepeat = scenario do
 
   let
     moves = [
-      (white, ("A", 2), ("A", 4)),
-      (black, ("A", 7), ("A", 5)),
+      (white, A2, A4),
+      (black, A7, A5),
       -- (1) Move the A column rooks forward and back.
-      (white, ("A", 1), ("A", 3)),
-      (black, ("A", 8), ("A", 6)),
-      (white, ("A", 3), ("A", 1)),
-      (black, ("A", 6), ("A", 8)),
+      (white, A1, A3),
+      (black, A8, A6),
+      (white, A3, A1),
+      (black, A6, A8),
       -- (2)
-      (white, ("A", 1), ("A", 3)),
-      (black, ("A", 8), ("A", 6)),
-      (white, ("A", 3), ("A", 1)),
-      (black, ("A", 6), ("A", 8)),
+      (white, A1, A3),
+      (black, A8, A6),
+      (white, A3, A1),
+      (black, A6, A8),
       -- (3)
-      (white, ("A", 1), ("A", 3)),
-      (black, ("A", 8), ("A", 6)),
-      (white, ("A", 3), ("A", 1)),
-      (black, ("A", 6), ("A", 8))
+      (white, A1, A3),
+      (black, A8, A6),
+      (white, A3, A1),
+      (black, A6, A8)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -59,19 +60,19 @@ testFiftyMove = scenario do
 
   let
     moves = [
-      (white, ("A", 2), ("A", 4)),
-      (black, ("A", 7), ("A", 5))
+      (white, A2, A4),
+      (black, A7, A5)
       ] ++
       (join (replicate 11 [
-        (white, ("A", 1), ("A", 3)),
-        (black, ("A", 8), ("A", 6)),
-        (white, ("A", 3), ("A", 1)),
-        (black, ("A", 6), ("A", 8))
+        (white, A1, A3),
+        (black, A8, A6),
+        (white, A3, A1),
+        (black, A6, A8)
       ])) ++
       [
-        (white, ("A", 1), ("A", 3)),
-        (black, ("A", 8), ("A", 6)),
-        (white, ("A", 3), ("B", 3))
+        (white, A1, A3),
+        (black, A8, A6),
+        (white, A3, B3)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -81,7 +82,7 @@ testFiftyMove = scenario do
         exercise g ClaimDraw
     Left _ -> abort "Should be in play"
 
-  game <- takeMove (return game) (black, ("A", 6), ("A", 8))
+  game <- takeMove (return game) (black, A6, A8)
 
 
   draw <- case game of

--- a/chess/daml/Tests/Draw.daml
+++ b/chess/daml/Tests/Draw.daml
@@ -20,13 +20,13 @@ testThreeRepeat = scenario do
   let
     moves = [
       (white, ("A", 2), ("A", 4)),
-      (black, ("A", 7), ("A", 5)),  
+      (black, ("A", 7), ("A", 5)),
       -- (1) Move the A column rooks forward and back.
       (white, ("A", 1), ("A", 3)),
       (black, ("A", 8), ("A", 6)),
       (white, ("A", 3), ("A", 1)),
       (black, ("A", 6), ("A", 8)),
-      -- (2) 
+      -- (2)
       (white, ("A", 1), ("A", 3)),
       (black, ("A", 8), ("A", 6)),
       (white, ("A", 3), ("A", 1)),

--- a/chess/daml/Tests/Draw.daml
+++ b/chess/daml/Tests/Draw.daml
@@ -20,19 +20,18 @@ testThreeRepeat = scenario do
   let
     moves = [
       (white, ("A", 2), ("A", 4)),
-      (black, ("A", 7), ("A", 5)),
+      (black, ("A", 7), ("A", 5)),  
+      -- (1) Move the A column rooks forward and back.
       (white, ("A", 1), ("A", 3)),
       (black, ("A", 8), ("A", 6)),
       (white, ("A", 3), ("A", 1)),
       (black, ("A", 6), ("A", 8)),
+      -- (2) 
       (white, ("A", 1), ("A", 3)),
       (black, ("A", 8), ("A", 6)),
       (white, ("A", 3), ("A", 1)),
       (black, ("A", 6), ("A", 8)),
-      (white, ("A", 1), ("A", 3)),
-      (black, ("A", 8), ("A", 6)),
-      (white, ("A", 3), ("A", 1)),
-      (black, ("A", 6), ("A", 8)),
+      -- (3)
       (white, ("A", 1), ("A", 3)),
       (black, ("A", 8), ("A", 6)),
       (white, ("A", 3), ("A", 1)),

--- a/chess/daml/Tests/Rules.daml
+++ b/chess/daml/Tests/Rules.daml
@@ -24,12 +24,8 @@ initStateWin = scenario do
     Some p -> abort $ show p
 
 testIntCoord = scenario do
-  intCoord (Coord with row = 1; col = "C") === Right (3, 1)
-  intCoord (Coord with row = 8; col = "H") === Right (8, 8)
-  intCoord (Coord with row = 8; col = "I") === Left "Col coordinate must be between A and H"
-  intCoord (Coord with row = 8; col = "a") === Left "Col coordinate must be between A and H"
-  intCoord (Coord with row = 0; col = "A") === Left "Row coordinate must be between 1 and 8"
-  intCoord (Coord with row = 9; col = "A") === Left "Row coordinate must be between 1 and 8"
+  toIntCoord C1 === (2, 0)
+  toIntCoord H8 === (7, 7)
 
 testCheckWin = scenario do
   let
@@ -45,124 +41,124 @@ testCheckWin = scenario do
   checkWin blackWin === Some Black
 
 testPathBetween = scenario do
-  pathBetween (3,3) (5,5) === Right [(4,4)]
-  pathBetween (3,3) (6,3) === Right [(4,3), (5,3)]
-  pathBetween (3,3) (5,1) === Right [(4,2)]
-  pathBetween (3,3) (3,1) === Right [(3,2)]
-  pathBetween (3,3) (2,2) === Right []
-  pathBetween (3,3) (1,3) === Right [(2,3)]
-  pathBetween (3,3) (1,5) === Right [(2,4)]
-  pathBetween (3,3) (3,6) === Right [(3,4), (3, 5)]
-  pathBetween (3,3) (4,6) === Left "Not a straight path"
+  pathBetween (2,2) (4,4) === Right [(3,3)]
+  pathBetween (2,2) (5,2) === Right [(3,2), (4,2)]
+  pathBetween (2,2) (4,0) === Right [(3,1)]
+  pathBetween (2,2) (2,0) === Right [(2,1)]
+  pathBetween (2,2) (1,1) === Right []
+  pathBetween (2,2) (0,2) === Right [(1,2)]
+  pathBetween (2,2) (0,4) === Right [(1,3)]
+  pathBetween (2,2) (2,5) === Right [(2,3), (2, 4)]
+  pathBetween (2,2) (3,5) === Left "Not a straight path"
 
 testPawnPath = scenario do
-  path Pawn White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path Pawn White False (5, 2) (5, 3) === Right []
-  path Pawn White False (5, 2) (5, 4) === Right [(5, 3)]
-  path Pawn White False (5, 2) (4, 3) === Left "Invalid move"
+  path Pawn White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path Pawn White False (4, 1) (4, 2) === Right []
+  path Pawn White False (4, 1) (4, 3) === Right [(4, 2)]
+  path Pawn White False (4, 1) (3, 2) === Left "Invalid move"
 
-  path Pawn White False (5, 3) (5, 4) === Right []
-  path Pawn White False (5, 3) (5, 5) === Left "Invalid move"
-  path Pawn White False (5, 3) (4, 2) === Left "Invalid move"
-  path Pawn White False (5, 3) (4, 4) === Left "Invalid move"
+  path Pawn White False (4, 2) (4, 3) === Right []
+  path Pawn White False (4, 2) (4, 4) === Left "Invalid move"
+  path Pawn White False (4, 2) (3, 1) === Left "Invalid move"
+  path Pawn White False (4, 2) (3, 3) === Left "Invalid move"
 
-  path Pawn White True (5, 2) (5, 2) === Left "Null move is not valid"
-  path Pawn White True (5, 2) (5, 3) === Left "Invalid move"
-  path Pawn White True (5, 2) (5, 4) === Left "Invalid move"
-  path Pawn White True (5, 2) (4, 3) === Right []
+  path Pawn White True (4, 1) (4, 1) === Left "Null move is not valid"
+  path Pawn White True (4, 1) (4, 2) === Left "Invalid move"
+  path Pawn White True (4, 1) (4, 3) === Left "Invalid move"
+  path Pawn White True (4, 1) (3, 2) === Right []
 
-  path Pawn White True (5, 3) (5, 4) === Left "Invalid move"
-  path Pawn White True (5, 3) (5, 5) === Left "Invalid move"
-  path Pawn White True (5, 3) (4, 2) === Left "Invalid move"
-  path Pawn White True (5, 3) (4, 4) === Right []
+  path Pawn White True (4, 2) (4, 3) === Left "Invalid move"
+  path Pawn White True (4, 2) (4, 4) === Left "Invalid move"
+  path Pawn White True (4, 2) (3, 1) === Left "Invalid move"
+  path Pawn White True (4, 2) (3, 3) === Right []
 
-  path Pawn Black False (5, 7) (5, 7) === Left "Null move is not valid"
-  path Pawn Black False (5, 7) (5, 6) === Right []
-  path Pawn Black False (5, 7) (5, 5) === Right [(5, 6)]
-  path Pawn Black False (5, 7) (4, 6) === Left "Invalid move"
+  path Pawn Black False (4, 6) (4, 6) === Left "Null move is not valid"
+  path Pawn Black False (4, 6) (4, 5) === Right []
+  path Pawn Black False (4, 6) (4, 4) === Right [(4, 5)]
+  path Pawn Black False (4, 6) (3, 5) === Left "Invalid move"
 
-  path Pawn Black False (5, 6) (5, 5) === Right []
-  path Pawn Black False (5, 6) (5, 4) === Left "Invalid move"
-  path Pawn Black False (5, 6) (4, 7) === Left "Invalid move"
-  path Pawn Black False (5, 6) (4, 5) === Left "Invalid move"
+  path Pawn Black False (4, 5) (4, 4) === Right []
+  path Pawn Black False (4, 5) (4, 3) === Left "Invalid move"
+  path Pawn Black False (4, 5) (3, 6) === Left "Invalid move"
+  path Pawn Black False (4, 5) (3, 4) === Left "Invalid move"
 
-  path Pawn Black True (5, 7) (5, 7) === Left "Null move is not valid"
-  path Pawn Black True (5, 7) (5, 6) === Left "Invalid move"
-  path Pawn Black True (5, 7) (5, 5) === Left "Invalid move"
-  path Pawn Black True (5, 7) (4, 6) === Right []
+  path Pawn Black True (4, 6) (4, 6) === Left "Null move is not valid"
+  path Pawn Black True (4, 6) (4, 5) === Left "Invalid move"
+  path Pawn Black True (4, 6) (4, 4) === Left "Invalid move"
+  path Pawn Black True (4, 6) (3, 5) === Right []
 
-  path Pawn Black True (5, 6) (5, 5) === Left "Invalid move"
-  path Pawn Black True (5, 6) (5, 4) === Left "Invalid move"
-  path Pawn Black True (5, 6) (4, 7) === Left "Invalid move"
-  path Pawn Black True (5, 6) (4, 5) === Right []
+  path Pawn Black True (4, 5) (4, 4) === Left "Invalid move"
+  path Pawn Black True (4, 5) (4, 3) === Left "Invalid move"
+  path Pawn Black True (4, 5) (3, 6) === Left "Invalid move"
+  path Pawn Black True (4, 5) (3, 4) === Right []
 
 testRookPath = scenario do
-  path Rook White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path Rook White False (5, 2) (8, 2) === Right [(6,2), (7,2)]
-  path Rook White False (5, 2) (3, 2) === Right [(4,2)]
-  path Rook White False (5, 2) (5, 1) === Right []
-  path Rook White False (5, 2) (5, 4) === Right [(5,3)]
-  path Rook White False (5, 2) (6, 3) === Left "Invalid move"
+  path Rook White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path Rook White False (4, 1) (7, 1) === Right [(5,1), (6,1)]
+  path Rook White False (4, 1) (2, 1) === Right [(3,1)]
+  path Rook White False (4, 1) (4, 0) === Right []
+  path Rook White False (4, 1) (4, 3) === Right [(4,2)]
+  path Rook White False (4, 1) (5, 2) === Left "Invalid move"
 
 testKnightPath = scenario do
-  path Knight White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path Knight White False (4, 4) (6, 5) === Right []
-  path Knight White False (4, 4) (6, 3) === Right []
-  path Knight White False (4, 4) (5, 2) === Right []
-  path Knight White False (4, 4) (5, 6) === Right []
-  path Knight White False (4, 4) (3, 6) === Right []
-  path Knight White False (4, 4) (3, 2) === Right []
-  path Knight White False (4, 4) (2, 5) === Right []
-  path Knight White False (4, 4) (2, 3) === Right []
-  path Knight White False (5, 2) (6, 3) === Left "Invalid move"
+  path Knight White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path Knight White False (3, 3) (5, 4) === Right []
+  path Knight White False (3, 3) (5, 2) === Right []
+  path Knight White False (3, 3) (4, 1) === Right []
+  path Knight White False (3, 3) (4, 5) === Right []
+  path Knight White False (3, 3) (2, 5) === Right []
+  path Knight White False (3, 3) (2, 1) === Right []
+  path Knight White False (3, 3) (1, 4) === Right []
+  path Knight White False (3, 3) (1, 2) === Right []
+  path Knight White False (4, 1) (5, 2) === Left "Invalid move"
 
 testBishopPath = scenario do
-  path Bishop White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path Bishop White False (5, 2) (8, 5) === Right [(6,3), (7,4)]
-  path Bishop White False (5, 2) (6, 1) === Right []
-  path Bishop White False (5, 2) (4, 1) === Right []
-  path Bishop White False (5, 2) (3, 4) === Right [(4,3)]
-  path Bishop White False (5, 2) (5, 3) === Left "Invalid move"
+  path Bishop White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path Bishop White False (4, 1) (7, 4) === Right [(5,2), (6,3)]
+  path Bishop White False (4, 1) (5, 0) === Right []
+  path Bishop White False (4, 1) (3, 0) === Right []
+  path Bishop White False (4, 1) (2, 3) === Right [(3,2)]
+  path Bishop White False (4, 1) (4, 2) === Left "Invalid move"
 
 testQueenPath = scenario do
-  path Queen White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path Queen White False (5, 2) (8, 5) === Right [(6,3), (7,4)]
-  path Queen White False (5, 2) (6, 1) === Right []
-  path Queen White False (5, 2) (4, 1) === Right []
-  path Queen White False (5, 2) (3, 4) === Right [(4,3)]
-  path Queen White False (5, 2) (8, 2) === Right [(6,2), (7,2)]
-  path Queen White False (5, 2) (3, 2) === Right [(4,2)]
-  path Queen White False (5, 2) (5, 1) === Right []
-  path Queen White False (5, 2) (5, 4) === Right [(5,3)]
-  path Queen White False (5, 2) (6, 4) === Left "Not a straight path"
+  path Queen White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path Queen White False (4, 1) (7, 4) === Right [(5,2), (6,3)]
+  path Queen White False (4, 1) (5, 0) === Right []
+  path Queen White False (4, 1) (3, 0) === Right []
+  path Queen White False (4, 1) (2, 3) === Right [(3,2)]
+  path Queen White False (4, 1) (7, 1) === Right [(5,1), (6,1)]
+  path Queen White False (4, 1) (2, 1) === Right [(3,1)]
+  path Queen White False (4, 1) (4, 0) === Right []
+  path Queen White False (4, 1) (4, 3) === Right [(4,2)]
+  path Queen White False (4, 1) (5, 3) === Left "Not a straight path"
 
 testKingPath = scenario do
-  path King White False (5, 2) (5, 2) === Left "Null move is not valid"
-  path King White False (4, 4) (5, 5) === Right []
-  path King White False (4, 4) (5, 4) === Right []
-  path King White False (4, 4) (5, 3) === Right []
-  path King White False (4, 4) (4, 3) === Right []
-  path King White False (4, 4) (3, 3) === Right []
-  path King White False (4, 4) (3, 4) === Right []
-  path King White False (4, 4) (3, 5) === Right []
-  path King White False (4, 4) (4, 5) === Right []
-  path King White False (4, 4) (4, 6) === Left "Invalid move"
+  path King White False (4, 1) (4, 1) === Left "Null move is not valid"
+  path King White False (3, 3) (4, 4) === Right []
+  path King White False (3, 3) (4, 3) === Right []
+  path King White False (3, 3) (4, 2) === Right []
+  path King White False (3, 3) (3, 2) === Right []
+  path King White False (3, 3) (2, 2) === Right []
+  path King White False (3, 3) (2, 3) === Right []
+  path King White False (3, 3) (2, 4) === Right []
+  path King White False (3, 3) (3, 4) === Right []
+  path King White False (3, 3) (3, 5) === Left "Invalid move"
 
-takeMove : (Either Text GameState) -> ((Text, Int), (Text, Int)) -> (Either Text GameState)
-takeMove eg m = do
+takeMove : (Either Text GameState) -> (Coord, Coord) -> (Either Text GameState)
+takeMove eg (from, to) = do
       g <- eg
       tryMoveInner g $
-        ChessMove (uncurry Coord m._1) (uncurry Coord m._2) None None
+        ChessMove from to None None
 
 testFoolsMateInner = scenario do
   let
     moves = [
-      (("G", 2), ("G", 4)),
-      (("E", 7), ("E", 6)),
-      (("F", 2), ("F", 4)),
-      (("D", 8), ("H", 4)),
-      (("E", 1), ("F", 2)),
-      (("H", 4), ("F", 2))
+      (G2, G4),
+      (E7, E6),
+      (F2, F4),
+      (D8, H4),
+      (E1, F2),
+      (H4, F2)
       ]
     game = foldl takeMove (Right $ initState ()) moves
 
@@ -172,7 +168,7 @@ testFoolsMateInner = scenario do
 
 testBlocked = scenario do
   let
-    moves = [(("D", 1), ("D", 7))]
+    moves = [(D1, D7)]
     game = foldl takeMove (Right $ initState ()) moves
 
   game === Left "Path blocked"

--- a/chess/daml/Tests/SpecialRules.daml
+++ b/chess/daml/Tests/SpecialRules.daml
@@ -4,7 +4,7 @@
 daml 1.2
 module Tests.SpecialRules where
 
-import DA.Map as M
+import DA.Next.Map as M
 import DA.Either
 
 import Chess

--- a/chess/daml/Tests/SpecialRules.daml
+++ b/chess/daml/Tests/SpecialRules.daml
@@ -22,18 +22,18 @@ testCastle = scenario do
   submitMustFail white do
     exercise game Move with
           move = ChessMove with
-            from = Coord "E" 1
-            to = Coord "G" 1
+            from = E1
+            to = G1
             promote = None
             check = None
   let
     moves = [
-      (white, ("G", 2), ("G", 4)),
-      (black, ("G", 7), ("G", 6)),
-      (white, ("F", 1), ("H", 3)),
-      (black, ("G", 6), ("G", 5)),
-      (white, ("G", 1), ("F", 3)),
-      (black, ("F", 8), ("H", 6))
+      (white, G2, G4),
+      (black, G7, G6),
+      (white, F1, H3),
+      (black, G6, G5),
+      (white, G1, F3),
+      (black, F8, H6)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -42,8 +42,8 @@ testCastle = scenario do
       submit white do
         exercise g Move with
           move = ChessMove with
-            from = Coord "E" 1
-            to = Coord "G" 1
+            from = E1
+            to = G1
             promote = None
             check = None
     Left _ -> abort "Should be in play"
@@ -54,10 +54,10 @@ testCastle = scenario do
       let
         t = do
           sm <- mapState kc.state
-          king <- optionalToEither "King position not occupied" $ M.lookup (7,1) sm
+          king <- optionalToEither "King position not occupied" $ M.lookup (6,0) sm
           assertMsg "No King in expected position"
             (king.tp == King && king.moved)
-          rook <- optionalToEither "Rook position not occupied" $ M.lookup (6,1) sm
+          rook <- optionalToEither "Rook position not occupied" $ M.lookup (5,0) sm
           assertMsg "No Rook in expected position"
             (rook.tp == Rook && rook.moved)
       case t of
@@ -71,15 +71,15 @@ testCheck = scenario do
   submitMustFail white do
     exercise game Move with
           move = ChessMove with
-            from = Coord "E" 1
-            to = Coord "G" 1
+            from = E1
+            to = G1
             promote = None
-            check = Some ((Coord "H" 4), (Coord "E" 1))
+            check = Some (H4, E1)
   let
     moves = [
-      (white, ("G", 2), ("G", 4)),
-      (black, ("E", 7), ("E", 6)),
-      (white, ("F", 2), ("F", 4))
+      (white, G2, G4),
+      (black, E7, E6),
+      (white, F2, F4)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -88,10 +88,10 @@ testCheck = scenario do
       submit black do
         exercise g Move with
           move = ChessMove with
-            from = Coord "D" 8
-            to = Coord "H" 4
+            from = D8
+            to = H4
             promote = None
-            check = Some ((Coord "H" 4), (Coord "E" 1))
+            check = Some (H4, E1)
     Left _ -> abort "Should be in play"
 
   case check of
@@ -106,16 +106,16 @@ testEnPassant = scenario do
   submitMustFail white do
     exercise game Move with
           move = ChessMove with
-            from = Coord "B" 2
-            to = Coord "C" 3
+            from = B2
+            to = C3
             promote = None
             check = None
   let
     moves = [
-      (white, ("B", 2), ("B", 4)),
-      (black, ("E", 7), ("E", 6)),
-      (white, ("B", 4), ("B", 5)),
-      (black, ("C", 7), ("C", 5))
+      (white, B2, B4),
+      (black, E7, E6),
+      (white, B4, B5),
+      (black, C7, C5)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -124,8 +124,8 @@ testEnPassant = scenario do
       submit white do
         exercise g Move with
           move = ChessMove with
-            from = Coord "B" 5
-            to = Coord "C" 6
+            from = B5
+            to = C6
             promote = None
             check = None
     Left _ -> abort "Should be in play"
@@ -148,24 +148,24 @@ testPromote = scenario do
   submitMustFail white do
     exercise game Move with
           move = ChessMove with
-            from = Coord "B" 2
-            to = Coord "C" 3
+            from = B2
+            to = C3
             promote = Some Queen
             check = None
   let
     moves = [
-      (white, ("A", 2), ("A", 4)),
-      (black, ("A", 7), ("A", 5)),
-      (white, ("B", 2), ("B", 4)),
-      (black, ("A", 5), ("B", 4)),
-      (white, ("A", 4), ("A", 5)),
-      (black, ("A", 8), ("A", 6)),
-      (white, ("C", 2), ("C", 3)),
-      (black, ("A", 6), ("H", 6)),
-      (white, ("A", 5), ("A", 6)),
-      (black, ("H", 6), ("G", 6)),
-      (white, ("A", 6), ("A", 7)),
-      (black, ("G", 6), ("H", 6))
+      (white, A2, A4),
+      (black, A7, A5),
+      (white, B2, B4),
+      (black, A5, B4),
+      (white, A4, A5),
+      (black, A8, A6),
+      (white, C2, C3),
+      (black, A6, H6),
+      (white, A5, A6),
+      (black, H6, G6),
+      (white, A6, A7),
+      (black, G6, H6)
       ]
   game <- foldl takeMove (return $ Right game) moves
 
@@ -174,8 +174,8 @@ testPromote = scenario do
       submit white do
         exercise g Move with
           move = ChessMove with
-            from = Coord "A" 7
-            to = Coord "A" 8
+            from = A7
+            to = A8
             promote = Some Queen
             check = None
     Left _ -> abort "Should be in play"
@@ -186,7 +186,7 @@ testPromote = scenario do
       let
         t = do
           sm <- mapState p.state
-          queen <- optionalToEither "Queen position not occupied" $ M.lookup (1,8) sm
+          queen <- optionalToEither "Queen position not occupied" $ M.lookup (0,7) sm
           assertMsg ("No Queen in expected position: " <> show queen)
             (queen.tp == Queen && queen.moved)
       case t of

--- a/chess/daml/Tests/SpecialRules.daml
+++ b/chess/daml/Tests/SpecialRules.daml
@@ -6,6 +6,7 @@ module Tests.SpecialRules where
 
 import DA.Next.Map as M
 import DA.Either
+import DA.Optional
 
 import Chess
 import Init
@@ -55,10 +56,10 @@ testCastle = scenario do
           sm <- mapState kc.state
           king <- optionalToEither "King position not occupied" $ M.lookup (7,1) sm
           assertMsg "No King in expected position"
-            (king.tp == King && king.moved == True)
+            (king.tp == King && king.moved)
           rook <- optionalToEither "Rook position not occupied" $ M.lookup (6,1) sm
           assertMsg "No Rook in expected position"
-            (rook.tp == Rook && rook.moved == True)
+            (rook.tp == Rook && rook.moved)
       case t of
         Left e -> abort e
         Right _ -> assert True
@@ -135,7 +136,7 @@ testEnPassant = scenario do
       let
         t = do
           sm <- mapState ep.state
-          assertMsg "Black pawn should be gone" (None == M.lookup (3,5) sm)
+          assertMsg "Black pawn should be gone" (isNone (M.lookup (3,5) sm))
       case t of
         Left e -> abort e
         Right _ -> assert True
@@ -187,7 +188,7 @@ testPromote = scenario do
           sm <- mapState p.state
           queen <- optionalToEither "Queen position not occupied" $ M.lookup (1,8) sm
           assertMsg ("No Queen in expected position: " <> show queen)
-            (queen.tp == Queen && queen.moved == True)
+            (queen.tp == Queen && queen.moved)
       case t of
         Left e -> abort e
         Right _ -> assert True

--- a/chess/daml/Types.daml
+++ b/chess/daml/Types.daml
@@ -13,6 +13,12 @@ data GameId = GameId with
   black : Party
     deriving (Eq, Show)
 
+oppositePlayer : Party -> GameId -> Party
+oppositePlayer player gameId =
+  if player == gameId.white
+  then gameId.black
+  else gameId.white
+
 data PieceType =
   Pawn | Rook | Knight | Bishop | Queen | King
     deriving (Eq, Show, Ord)

--- a/chess/daml/Types.daml
+++ b/chess/daml/Types.daml
@@ -4,8 +4,7 @@
 daml 1.2
 module Types where
 
-import DA.Next.Map
-import DA.Text as T
+import DA.Next.Map as M
 
 data GameId = GameId with
   ref : Text
@@ -27,16 +26,19 @@ data Player =
   Black | White
     deriving (Eq, Show, Ord)
 
-data Coord = Coord with
-  col : Text
-  row : Int
-    deriving (Eq, Show, Ord)
+data Coord = A1 | A2 | A3 | A4 | A5 | A6 | A7 | A8
+           | B1 | B2 | B3 | B4 | B5 | B6 | B7 | B8
+           | C1 | C2 | C3 | C4 | C5 | C6 | C7 | C8
+           | D1 | D2 | D3 | D4 | D5 | D6 | D7 | D8
+           | E1 | E2 | E3 | E4 | E5 | E6 | E7 | E8
+           | F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8
+           | G1 | G2 | G3 | G4 | G5 | G6 | G7 | G8
+           | H1 | H2 | H3 | H4 | H5 | H6 | H7 | H8
+    deriving (Eq, Show, Ord, Enum)
 
 instance MapKey Coord where
-  keyToText c = c.col <> ";" <> keyToText c.row
-  keyFromText t = case T.splitOn ";" t of
-    [a, b] -> Coord with col = a; row = keyFromText b
-    _ -> error "malformatted key"
+  keyToText c = keyToText $ fromEnum c
+  keyFromText t = toEnum $ keyFromText t
 
 data Piece = Piece with
   coord : Coord


### PR DESCRIPTION
This PR changes the way that we users can refer to coordinates into a more natural (for Chess players at least 😄 ) form, ex `D2` to `D4`.

This change might seem superficial but it helps to simplify looking at contract code.

It also builds on the [draw PR](https://github.com/digital-asset/ex-models/pull/36) and should be considered afterwards.